### PR TITLE
Launch LockClock from settings

### DIFF
--- a/res/values/slim_strings.xml
+++ b/res/values/slim_strings.xml
@@ -1331,6 +1331,16 @@
     <string name="dlg_reset_disable">Disable</string>
     <string name="dlg_reset_ok">OK</string>
 
+    <!-- Lock clock -->
+    <string name="lock_clock_title">Clock widget</string>
+    <string name="lock_clock_summary">View or change how the cLock widget will display</string>
+    <string name="lock_clock_clock_section_title">Clock and alarm</string>
+    <string name="lock_clock_clock_section_summary">View or change how the clock of the cLock widget will display</string>
+    <string name="lock_clock_weather_section_title">Weather panel</string>
+    <string name="lock_clock_weather_section_summary">View or change how the weather of the cLock widget will display</string>
+    <string name="lock_clock_calendar_section_title">Calendar events</string>
+    <string name="lock_clock_calendar_section_summary">View or change how the calendar of the cLock widget will display</string>
+
     <!-- Navigation Ring Targets -->
     <string name="navigation_ring_title">Navigation ring targets</string>
     <string name="navigation_ring_enable_title">Enable navigation rings</string>

--- a/res/xml/lock_clock.xml
+++ b/res/xml/lock_clock.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2014 The CyanogenMod Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<PreferenceScreen
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:title="@string/lock_clock_title"
+    xmlns:settings="http://schemas.android.com/apk/res/com.android.settings">
+
+    <PreferenceScreen
+        android:key="lock_clock_clock_section"
+        android:title="@string/lock_clock_clock_section_title"
+        android:summary="@string/lock_clock_clock_section_summary" >
+        <intent
+            android:action="android.intent.action.MAIN"
+            android:targetClass="com.cyanogenmod.lockclock.preference.Preferences"
+            android:targetPackage="com.cyanogenmod.lockclock" >
+            <extra android:name=":android:show_fragment"
+                android:value="com.cyanogenmod.lockclock.preference.ClockPreferences" />
+        </intent>
+    </PreferenceScreen>
+
+    <PreferenceScreen
+        android:key="lock_clock_weather_section"
+        android:title="@string/lock_clock_weather_section_title"
+        android:summary="@string/lock_clock_weather_section_summary" >
+        <intent
+            android:action="android.intent.action.MAIN"
+            android:targetClass="com.cyanogenmod.lockclock.preference.Preferences"
+            android:targetPackage="com.cyanogenmod.lockclock" >
+            <extra android:name=":android:show_fragment"
+                android:value="com.cyanogenmod.lockclock.preference.WeatherPreferences" />
+        </intent>
+    </PreferenceScreen>
+
+    <PreferenceScreen
+        android:key="lock_clock_calendar_section"
+        android:title="@string/lock_clock_calendar_section_title"
+        android:summary="@string/lock_clock_calendar_section_summary" >
+        <intent
+            android:action="android.intent.action.MAIN"
+            android:targetClass="com.cyanogenmod.lockclock.preference.Preferences"
+            android:targetPackage="com.cyanogenmod.lockclock" >
+            <extra android:name=":android:show_fragment"
+                android:value="com.cyanogenmod.lockclock.preference.CalendarPreferences" />
+        </intent>
+    </PreferenceScreen>
+
+</PreferenceScreen>

--- a/res/xml/slim_advanced_settings.xml
+++ b/res/xml/slim_advanced_settings.xml
@@ -102,6 +102,12 @@
         android:title="@string/misc_category_title">
 
         <PreferenceScreen
+            android:key="lock_clock"
+            android:title="@string/lock_clock_title"
+            android:summary="@string/lock_clock_summary"
+            android:fragment="com.android.settings.slim.LockClock" />
+
+        <PreferenceScreen
             android:key="screen_recorder"
             android:title="@string/screen_recorder_title"
             android:summary="@string/screen_recorder_summary"

--- a/src/com/android/settings/slim/LockClock.java
+++ b/src/com/android/settings/slim/LockClock.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2014 The CyanogenMod Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.android.settings.slim;
+
+import android.os.Bundle;
+import android.content.res.Resources;
+import android.preference.Preference;
+import android.preference.Preference.OnPreferenceChangeListener;
+
+import com.android.settings.SettingsPreferenceFragment;
+import com.android.settings.R;
+
+public class LockClock extends SettingsPreferenceFragment implements
+        Preference.OnPreferenceChangeListener {
+
+    private static final String TAG = "LockClock";
+
+    @Override
+    public void onCreate(Bundle icicle) {
+        super.onCreate(icicle);
+        addPreferencesFromResource(R.xml.lock_clock);
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+    }
+
+    public boolean onPreferenceChange(Preference preference, Object objValue) {
+        return false;
+    }
+}


### PR DESCRIPTION
May be easier for some users to configure for weather related options and the widget itself. 
